### PR TITLE
extend result objects with additional methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ conn.query("select 1 id, 'bob' name").each do |user|
   puts user.id # 1
 end
 
+# extend result objects with additional method
+module Product
+  def amount_price
+    price * quantity
+  end
+end
+
+conn.query("select 20 price, 3 quantity", included_module: Product).each do |user|
+  puts user.amount_price # 60
+end
+
 p conn.query_single('select 1 union select 2')
 # [1,2]
 

--- a/lib/mini_sql/postgres/connection.rb
+++ b/lib/mini_sql/postgres/connection.rb
@@ -78,7 +78,11 @@ module MiniSql
         result.clear if result
       end
 
-      def query(sql, *params, included_module:)
+      def query(sql, *params)
+        included_module =
+          if (h = params&.first)&.is_a?(Hash)
+            h.delete(:included_module)
+          end
         result = run(sql, params)
         result.type_map = type_map
         @deserializer_cache.materialize(result, included_module)

--- a/lib/mini_sql/postgres/connection.rb
+++ b/lib/mini_sql/postgres/connection.rb
@@ -78,10 +78,10 @@ module MiniSql
         result.clear if result
       end
 
-      def query(sql, *params)
+      def query(sql, *params, included_module:)
         result = run(sql, params)
         result.type_map = type_map
-        @deserializer_cache.materialize(result)
+        @deserializer_cache.materialize(result, included_module)
       ensure
         result.clear if result
       end

--- a/lib/mini_sql/postgres/connection.rb
+++ b/lib/mini_sql/postgres/connection.rb
@@ -79,10 +79,14 @@ module MiniSql
       end
 
       def query(sql, *params)
-        included_module =
-          if (h = params&.first)&.is_a?(Hash)
-            h.delete(:included_module)
-          end
+        result = run(sql, params)
+        result.type_map = type_map
+        @deserializer_cache.materialize(result)
+      ensure
+        result.clear if result
+      end
+
+      def query_typed(included_module, sql, *params)
         result = run(sql, params)
         result.type_map = type_map
         @deserializer_cache.materialize(result, included_module)

--- a/lib/mini_sql/postgres/deserializer_cache.rb
+++ b/lib/mini_sql/postgres/deserializer_cache.rb
@@ -9,7 +9,7 @@ module MiniSql
         @max_size = max_size || DEFAULT_MAX_SIZE
       end
 
-      def materialize(result, included_module)
+      def materialize(result, included_module = nil)
         return [] if result.ntuples == 0
 
         key = result.fields

--- a/test/mini_sql/postgres/connection_test.rb
+++ b/test/mini_sql/postgres/connection_test.rb
@@ -58,8 +58,8 @@ class MiniSql::Postgres::TestConnection < MiniTest::Test
     end
   end
 
-  def test_included_module
-    r = @connection.query('select 20 price, 3 quantity', included_module: Product).first
+  def test_query_typed
+    r = @connection.query_typed(Product, 'select 20 price, 3 quantity').first
     assert_equal(60, r.amount_price)
   end
 

--- a/test/mini_sql/postgres/connection_test.rb
+++ b/test/mini_sql/postgres/connection_test.rb
@@ -52,4 +52,15 @@ class MiniSql::Postgres::TestConnection < MiniTest::Test
     assert(delta < 5)
   end
 
+  module Product
+    def amount_price
+      price * quantity
+    end
+  end
+
+  def test_included_module
+    r = @connection.query('select 20 price, 3 quantity', included_module: Product).first
+    assert_equal(60, r.amount_price)
+  end
+
 end


### PR DESCRIPTION
Often need objects with additional behavior

maybe it’s better to use other name for the parameter - `instance_methods` or ...

What do you think?