### PR TITLE
empty array encoding compatibility with Sequel and ActiveRecord

### DIFF
--- a/lib/mini_sql/inline_param_encoder.rb
+++ b/lib/mini_sql/inline_param_encoder.rb
@@ -50,20 +50,19 @@ module MiniSql
 
     def quote_val(value)
       case value
+      when String     then "'#{conn.escape_string(value.to_s)}'"
+      when Numeric    then value.to_s
+      when BigDecimal then value.to_s("F")
+      when Date, Time then "'#{quoted_date(value)}'"
+      when Symbol     then "'#{conn.escape_string(value.to_s)}'"
+      when true       then "true"
+      when false      then "false"
+      when nil        then "NULL"
       when []         then "NULL"
       when Array
         value.map do |v|
           quote_val(v)
         end.join(', ')
-      when String
-        "'#{conn.escape_string(value.to_s)}'"
-      when true       then "true"
-      when false      then "false"
-      when nil        then "NULL"
-      when BigDecimal then value.to_s("F")
-      when Numeric then value.to_s
-      when Date, Time then "'#{quoted_date(value)}'"
-      when Symbol     then "'#{conn.escape_string(value.to_s)}'"
       else raise TypeError, "can't quote #{value.class.name}"
       end
     end

--- a/lib/mini_sql/inline_param_encoder.rb
+++ b/lib/mini_sql/inline_param_encoder.rb
@@ -50,6 +50,7 @@ module MiniSql
 
     def quote_val(value)
       case value
+      when []         then "NULL"
       when Array
         value.map do |v|
           quote_val(v)

--- a/test/mini_sql/inline_param_encoder_test.rb
+++ b/test/mini_sql/inline_param_encoder_test.rb
@@ -30,6 +30,11 @@ module MiniSql
       assert_equal("select 'a', 'a'''", result)
     end
 
+    def test_empty_array_encoding
+      result = @encoder.encode("select :str", str: [])
+      assert_equal("select NULL", result)
+    end
+
     def test_encode_times
       t = Time.parse('2010-10-01T02:22:00Z')
       result = @encoder.encode("select :t", t: t)


### PR DESCRIPTION
Sequel

```
DB.fetch("SELECT ?", []).sql
=> "SELECT (NULL)"
```

ActiveRecord

```
Product.find_by_sql(['select ? ', []])
  Product Load (0.7ms)  select NULL
```
