### PR TITLE
optimized LRU (70% less cpu time)

### DIFF
--- a/lib/mini_sql/mysql/deserializer_cache.rb
+++ b/lib/mini_sql/mysql/deserializer_cache.rb
@@ -15,13 +15,11 @@ module MiniSql
         key = result.fields
 
         # trivial fast LRU implementation
-        materializer = @cache.delete(key)
-        if materializer
-          @cache[key] = materializer
-        else
-          materializer = @cache[key] = new_row_matrializer(result)
-          @cache.shift if @cache.length > @max_size
-        end
+        materializer =
+          @cache[key] || begin
+            @cache.shift if @cache.size + 1 > @max_size
+            @cache[key] = new_row_matrializer(result)
+          end
 
         materializer.include(decorator_module) if decorator_module
 

--- a/lib/mini_sql/postgres_jdbc/deserializer_cache.rb
+++ b/lib/mini_sql/postgres_jdbc/deserializer_cache.rb
@@ -18,13 +18,11 @@ module MiniSql
         key = result.fields
 
         # trivial fast LRU implementation
-        materializer = @cache.delete(key)
-        if materializer
-          @cache[key] = materializer
-        else
-          materializer = @cache[key] = new_row_matrializer(result)
-          @cache.shift if @cache.length > @max_size
-        end
+        materializer =
+          @cache[key] || begin
+            @cache.shift if @cache.size + 1 > @max_size
+            @cache[key] = new_row_matrializer(result)
+          end
 
         materializer.include(decorator_module) if decorator_module
 

--- a/lib/mini_sql/sqlite/deserializer_cache.rb
+++ b/lib/mini_sql/sqlite/deserializer_cache.rb
@@ -16,13 +16,11 @@ module MiniSql
         key = result.columns
 
         # trivial fast LRU implementation
-        materializer = @cache.delete(key)
-        if materializer
-          @cache[key] = materializer
-        else
-          materializer = @cache[key] = new_row_matrializer(result)
-          @cache.shift if @cache.length > @max_size
-        end
+        materializer =
+          @cache[key] || begin
+            @cache.shift if @cache.size + 1 > @max_size
+            @cache[key] = new_row_matrializer(result)
+          end
 
         materializer.include(decorator_module) if decorator_module
 


### PR DESCRIPTION
```ruby
def new_row_matrializer
  fields = [:name, :id, :author_id]

  Class.new do
    attr_accessor(*fields)

    # AM serializer support
    alias :read_attribute_for_serialization :send

    def to_h
      r = {}
      instance_variables.each do |f|
        r[f.to_s.sub('@', '').to_sym] = instance_variable_get(f)
      end
      r
    end
  end
end

# exists key
Benchmark.ips do |r|
  r.report('LRU old') do |n|
    @cache = (1..500).map{ |i| [[i, :id, :name], new_row_matrializer] }.to_h
    @max_size = 500
    key = [222, :id, :name]
    while n > 0
      materializer = @cache.delete(key)
      if materializer
        @cache[key] = materializer
      else
        materializer = @cache[key] = new_row_matrializer
        @cache.shift if @cache.length > @max_size
      end
      n -= 1
    end
  end

  r.report('LRU new') do |n|
    @cache = (1..500).map{ |i| [[i, :id, :name], new_row_matrializer] }.to_h
    @max_size = 500
    key = [222, :id, :name]
    while n > 0
      materializer =
        @cache[key] || begin
          @cache.shift if @cache.size + 1 > @max_size
          @cache[key] = new_row_matrializer
        end
      n -= 1
    end
  end

  r.compare!
end

# Comparison:
#              LRU new:   928394.3 i/s
#              LRU old:   545568.8 i/s - 1.70x  (± 0.00) slower


# new key over limit
Benchmark.ips do |r|
  r.report('LRU new') do |n|
    @cache = (1..500).map{ |i| [[i, :id, :name], new_row_matrializer] }.to_h
    @max_size = 500
    init_key = 501
    while n > 0
      key = [init_key+=1, :id, :name]
      materializer =
        @cache[key] || begin
          @cache.shift if @cache.size + 1 > @max_size
          @cache[key] = new_row_matrializer
        end

      n -= 1
    end
  end

  r.report('LRU old') do |n|
    @cache = (1..500).map{ |i| [[i, :id, :name], new_row_matrializer] }.to_h
    @max_size = 500
    init_key = 501
    while n > 0
      key = [init_key+=1, :id, :name]
      materializer = @cache.delete(key)
      if materializer
        @cache[key] = materializer
      else
        materializer = @cache[key] = new_row_matrializer
        @cache.shift if @cache.size > @max_size
      end
      n -= 1
    end
  end

  r.compare!
end


# Comparison:
#              LRU new:   110128.5 i/s
#              LRU old:   108438.8 i/s - same-ish: difference falls within error
```