### PR TITLE
remove double checked empty params

### DIFF
--- a/lib/mini_sql/mysql/connection.rb
+++ b/lib/mini_sql/mysql/connection.rb
@@ -50,9 +50,7 @@ module MiniSql
       private
 
       def run(sql, as, params)
-        if params && params.length > 0
-          sql = param_encoder.encode(sql, *params)
-        end
+        sql = param_encoder.encode(sql, *params)
         raw_connection.query(
           sql,
           as: as,

--- a/lib/mini_sql/postgres/connection.rb
+++ b/lib/mini_sql/postgres/connection.rb
@@ -97,9 +97,7 @@ module MiniSql
 
       def query_each(sql, *params)
         raise StandardError, "Please supply a block when calling query_each" if !block_given?
-        if params && params.length > 0
-          sql = param_encoder.encode(sql, *params)
-        end
+        sql = param_encoder.encode(sql, *params)
 
         raw_connection.send_query(sql)
         raw_connection.set_single_row_mode
@@ -130,9 +128,7 @@ module MiniSql
 
       def query_each_hash(sql, *params)
         raise StandardError, "Please supply a block when calling query_each_hash" if !block_given?
-        if params && params.length > 0
-          sql = param_encoder.encode(sql, *params)
-        end
+        sql = param_encoder.encode(sql, *params)
 
         raw_connection.send_query(sql)
         raw_connection.set_single_row_mode
@@ -195,9 +191,7 @@ module MiniSql
       private
 
       def run(sql, params)
-        if params && params.length > 0
-          sql = param_encoder.encode(sql, *params)
-        end
+        sql = param_encoder.encode(sql, *params)
         raw_connection.async_exec(sql)
       end
 

--- a/lib/mini_sql/postgres_jdbc/connection.rb
+++ b/lib/mini_sql/postgres_jdbc/connection.rb
@@ -89,7 +89,7 @@ module MiniSql
       private
 
       def run(sql, params)
-        sql = param_encoder.encode(sql, *params) if params && params.length > 0
+        sql = param_encoder.encode(sql, *params)
         conn = raw_connection
         conn.typemap = self.class.typemap
         conn.execute(sql)

--- a/lib/mini_sql/sqlite/connection.rb
+++ b/lib/mini_sql/sqlite/connection.rb
@@ -63,9 +63,7 @@ module MiniSql
       private
 
       def run(sql, *params)
-        if params && params.length > 0
-          sql = param_encoder.encode(sql, *params)
-        end
+        sql = param_encoder.encode(sql, *params)
         if block_given?
           stmt = SQLite3::Statement.new(raw_connection, sql)
           yield stmt.execute


### PR DESCRIPTION
method  encode has checking params
```ruby
def encode(sql, *params)
  return sql unless params && params.length > 0

  if Hash === (hash = params[0])
    raise ArgumentError, "Only one hash param is allowed, multiple were sent" if params.length > 1
    encode_hash(sql, hash)
  else
    encode_array(sql, params)
  end
end
```

also it improves performance if params exists, this is the most used case than no parameters in real apps