### PR TITLE
optimized key for LRU hash (2x perfomance)

### DIFF
--- a/lib/mini_sql/mysql/deserializer_cache.rb
+++ b/lib/mini_sql/mysql/deserializer_cache.rb
@@ -12,7 +12,7 @@ module MiniSql
       end
 
       def materialize(result, decorator_module = nil)
-        key = result.fields
+        key = result.fields.hash
 
         # trivial fast LRU implementation
         materializer = @cache.delete(key)

--- a/lib/mini_sql/postgres/deserializer_cache.rb
+++ b/lib/mini_sql/postgres/deserializer_cache.rb
@@ -12,7 +12,7 @@ module MiniSql
       end
 
       def materializer(result)
-        key = result.fields
+        key = result.fields.hash
 
         materializer = @cache.delete(key)
         if materializer
@@ -28,7 +28,7 @@ module MiniSql
       def materialize(result, decorator_module = nil)
         return [] if result.ntuples == 0
 
-        key = result.fields
+        key = result.fields.hash
 
         # trivial fast LRU implementation
         materializer = @cache.delete(key)

--- a/lib/mini_sql/postgres_jdbc/deserializer_cache.rb
+++ b/lib/mini_sql/postgres_jdbc/deserializer_cache.rb
@@ -15,7 +15,7 @@ module MiniSql
 
         return [] if result.ntuples == 0
 
-        key = result.fields
+        key = result.fields.hash
 
         # trivial fast LRU implementation
         materializer = @cache.delete(key)

--- a/lib/mini_sql/sqlite/deserializer_cache.rb
+++ b/lib/mini_sql/sqlite/deserializer_cache.rb
@@ -13,7 +13,7 @@ module MiniSql
 
       def materialize(result, decorator_module = nil)
 
-        key = result.columns
+        key = result.columns.hash
 
         # trivial fast LRU implementation
         materializer = @cache.delete(key)


### PR DESCRIPTION
```ruby
def new_row_matrializer
  fields = [:name, :id, :author_id]

  Class.new do
    attr_accessor(*fields)

    # AM serializer support
    alias :read_attribute_for_serialization :send

    def to_h
      r = {}
      instance_variables.each do |f|
        r[f.to_s.sub('@', '').to_sym] = instance_variable_get(f)
      end
      r
    end
  end
end


@max_size = 500

# 3 fields
Benchmark.ips do |r|
  r.report('LRU init') do |n|
    @cache = (1..500).map{ |i| [[i, :id, :name], new_row_matrializer] }.to_h
    while n > 0
      key = [222, :id, :name]
      materializer = @cache.delete(key)
      if materializer
        @cache[key] = materializer
      else
        materializer = @cache[key] = new_row_matrializer
        @cache.shift if @cache.length > @max_size
      end
      n -= 1
    end
  end

  r.report('LRU optimized') do |n|
    @cache = (1..500).map{ |i| [[i, :id, :name].hash, new_row_matrializer] }.to_h
    while n > 0
      key = [222, :id, :name].hash
      materializer = @cache.delete(key)
      if materializer
        @cache[key] = materializer
      else
        materializer = @cache[key] = new_row_matrializer
        @cache.shift if @cache.length > @max_size
      end
      n -= 1
    end
  end

  r.compare!
end

# Comparison:
#        LRU optimized:  1091853.6 i/s
#             LRU init:   441457.1 i/s - 2.47x  (± 0.00) slower

# 12 fields
Benchmark.ips do |r|
  r.report('LRU init') do |n|
    @cache = (1..500).map{ |i| [[i, :id, :name, :title, :last_posted_at, :created_at, :updated_at, :views, :posts_count, :user_id, :last_post_user_id, :reply_count], new_row_matrializer] }.to_h
    while n > 0
      key = [222, :id, :name, :title, :last_posted_at, :created_at, :updated_at, :views, :posts_count, :user_id, :last_post_user_id, :reply_count]
      materializer = @cache.delete(key)
      if materializer
        @cache[key] = materializer
      else
        materializer = @cache[key] = new_row_matrializer
        @cache.shift if @cache.length > @max_size
      end
      n -= 1
    end
  end

  r.report('LRU optimized') do |n|
    @cache = (1..500).map{ |i| [[i, :id, :name, :title, :last_posted_at, :created_at, :updated_at, :views, :posts_count, :user_id, :last_post_user_id, :reply_count].hash, new_row_matrializer] }.to_h
    while n > 0
      key = [222, :id, :name, :title, :last_posted_at, :created_at, :updated_at, :views, :posts_count, :user_id, :last_post_user_id, :reply_count].hash
      materializer = @cache.delete(key)
      if materializer
        @cache[key] = materializer
      else
        materializer = @cache[key] = new_row_matrializer
        @cache.shift if @cache.length > @max_size
      end
      n -= 1
    end
  end

  r.compare!
end

# Comparison:
#        LRU optimized:   319924.8 i/s
#             LRU init:   156356.3 i/s - 2.05x  (± 0.00) slower
```