### PR TITLE
Compacted JSON serialization

### DIFF
--- a/lib/mini_sql.rb
+++ b/lib/mini_sql.rb
@@ -10,6 +10,7 @@ require_relative "mini_sql/builder"
 require_relative "mini_sql/inline_param_encoder"
 require_relative "mini_sql/decoratable"
 require_relative "mini_sql/serializer"
+require_relative "mini_sql/result"
 
 module MiniSql
   if RUBY_ENGINE == 'jruby'

--- a/lib/mini_sql/mysql/deserializer_cache.rb
+++ b/lib/mini_sql/mysql/deserializer_cache.rb
@@ -39,18 +39,9 @@ module MiniSql
 
         Class.new do
           extend MiniSql::Decoratable
+          include MiniSql::Result
+
           attr_accessor(*fields)
-
-          # AM serializer support
-          alias :read_attribute_for_serialization :send
-
-          def to_h
-            r = {}
-            instance_variables.each do |f|
-              r[f.to_s.sub('@', '').to_sym] = instance_variable_get(f)
-            end
-            r
-          end
 
           instance_eval <<~RUBY
             def materialize(data)

--- a/lib/mini_sql/postgres/deserializer_cache.rb
+++ b/lib/mini_sql/postgres/deserializer_cache.rb
@@ -69,18 +69,9 @@ module MiniSql
 
         Class.new do
           extend MiniSql::Decoratable
+          include MiniSql::Result
+          
           attr_accessor(*fields)
-
-          # AM serializer support
-          alias :read_attribute_for_serialization :send
-
-          def to_h
-            r = {}
-            instance_variables.each do |f|
-              r[f.to_s.sub('@', '').to_sym] = instance_variable_get(f)
-            end
-            r
-          end
 
           instance_eval <<~RUBY
             def materialize(pg_result, index)

--- a/lib/mini_sql/postgres/deserializer_cache.rb
+++ b/lib/mini_sql/postgres/deserializer_cache.rb
@@ -70,7 +70,7 @@ module MiniSql
         Class.new do
           extend MiniSql::Decoratable
           include MiniSql::Result
-          
+
           attr_accessor(*fields)
 
           instance_eval <<~RUBY

--- a/lib/mini_sql/postgres_jdbc/deserializer_cache.rb
+++ b/lib/mini_sql/postgres_jdbc/deserializer_cache.rb
@@ -49,18 +49,9 @@ module MiniSql
 
         Class.new do
           extend MiniSql::Decoratable
+          include MiniSql::Result
+          
           attr_accessor(*fields)
-
-          # AM serializer support
-          alias :read_attribute_for_serialization :send
-
-          def to_h
-            r = {}
-            instance_variables.each do |f|
-              r[f.to_s.sub('@', '').to_sym] = instance_variable_get(f)
-            end
-            r
-          end
 
           instance_eval <<~RUBY
             def materialize(pg_result, index)

--- a/lib/mini_sql/postgres_jdbc/deserializer_cache.rb
+++ b/lib/mini_sql/postgres_jdbc/deserializer_cache.rb
@@ -50,7 +50,7 @@ module MiniSql
         Class.new do
           extend MiniSql::Decoratable
           include MiniSql::Result
-          
+
           attr_accessor(*fields)
 
           instance_eval <<~RUBY

--- a/lib/mini_sql/result.rb
+++ b/lib/mini_sql/result.rb
@@ -8,7 +8,7 @@ module MiniSql
     def to_h
       r = {}
       instance_variables.each do |f|
-        r[f.to_s.sub('@', '').to_sym] = instance_variable_get(f)
+        r[f.to_s.delete('@').to_sym] = instance_variable_get(f)
       end
       r
     end

--- a/lib/mini_sql/result.rb
+++ b/lib/mini_sql/result.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module MiniSql
+  module Result
+    # AM serializer support
+    alias :read_attribute_for_serialization :send
+
+    def to_h
+      r = {}
+      instance_variables.each do |f|
+        r[f.to_s.sub('@', '').to_sym] = instance_variable_get(f)
+      end
+      r
+    end
+
+    def values
+      instance_variables.map { |f| instance_variable_get(f) }
+    end
+  end
+end

--- a/lib/mini_sql/result.rb
+++ b/lib/mini_sql/result.rb
@@ -8,7 +8,7 @@ module MiniSql
     def to_h
       r = {}
       instance_variables.each do |f|
-        r[f.to_s.delete('@').to_sym] = instance_variable_get(f)
+        r[f.to_s.delete_prefix('@').to_sym] = instance_variable_get(f)
       end
       r
     end

--- a/lib/mini_sql/sqlite/deserializer_cache.rb
+++ b/lib/mini_sql/sqlite/deserializer_cache.rb
@@ -46,18 +46,9 @@ module MiniSql
 
         Class.new do
           extend MiniSql::Decoratable
+          include MiniSql::Result
+
           attr_accessor(*fields)
-
-          # AM serializer support
-          alias :read_attribute_for_serialization :send
-
-          def to_h
-            r = {}
-            instance_variables.each do |f|
-              r[f.to_s.sub('@', '').to_sym] = instance_variable_get(f)
-            end
-            r
-          end
 
           instance_eval <<~RUBY
             def materialize(data)


### PR DESCRIPTION
Speeds up serialization and deserialization

```ruby
# frozen_string_literal: true

require 'benchmark/ips'
require 'mini_sql'
require 'json'

module MiniSql
  module Result
    # AM serializer support
    alias :read_attribute_for_serialization :send

    def to_h
      r = {}
      instance_variables.each do |f|
        r[f.to_s.delete('@').to_sym] = instance_variable_get(f)
      end
      r
    end

    def values
      instance_variables.map { |f| instance_variable_get(f) }
    end
  end

  module Postgres
    class DeserializerCache
      def new_row_matrializer(result)
        fields = result.fields

        i = 0
        while i < fields.length
          # special handling for unamed column
          if fields[i] == "?column?"
            fields[i] = "column#{i}"
          end
          i += 1
        end

        Class.new do
          extend MiniSql::Decoratable
          include MiniSql::Result

          attr_accessor(*fields)

          instance_eval <<~RUBY
            def materialize(pg_result, index)
              r = self.new
              #{col = -1; fields.map { |f| "r.#{f} = pg_result.getvalue(index, #{col += 1})" }.join("; ")}
              r
            end
          RUBY
        end
      end
    end
  end
end

module MiniSql
  module Serializer
    def self.from_json(json)
      wrapper = JSON.parse(json)
      if !wrapper["data"]
        []
      else
        materializer = cached_materializer(wrapper['data'][0].keys, wrapper['decorator'])
        wrapper["data"].map do |row|
          materializer.materialize(row)
        end
      end
    end

    def self.to_json_compacted(result)
      wrapper =
        if result.length == 0
          {}
        else
          {
            "decorator" => result[0].class.decorator.to_s,
            "fields" => result[0].to_h.keys,
            "data" => result.map(&:values),
          }
        end

      JSON.generate(wrapper)
    end

    def self.from_json_compacted(json)
      wrapper = JSON.parse(json)
      if !wrapper["data"]
        []
      else
        materializer = cached_materializer(wrapper['fields'], wrapper['decorator'])
        wrapper["data"].map do |row|
          materializer.materialize_from_array(row)
        end
      end
    end

    def self.cached_materializer(fields, decorator_module = nil)
      @cache ||= {}
      key = fields
      m = @cache.delete(key)
      if m
        @cache[key] = m
      else
        m = @cache[key] = materializer(fields)
        @cache.shift if @cache.length > MAX_CACHE_SIZE
      end

      if decorator_module && decorator_module.length > 0
        decorator = Kernel.const_get(decorator_module)
        m = m.decorated(decorator)
      end

      m
    end

    def self.materializer(fields)
      Class.new do
        extend MiniSql::Decoratable
        include MiniSql::Result

        attr_accessor(*fields)

        instance_eval <<~RUBY
          def materialize(hash)
            r = self.new
            #{fields.map { |f| "r.#{f} = hash['#{f}']" }.join("; ")}
            r
          end

          def materialize_from_array(values)
            r = self.new
            #{col = -1; fields.map { |f| "r.#{f} = values[#{col += 1}]" }.join("; ")}
            r
          end
        RUBY
      end
    end
  end
end

PgResult =
  Struct.new(:rows) do
    def ntuples
      rows.size
    end

    def fields
      @fields ||= rows[0].keys
    end

    def getvalue(row_num, col_num)
      rows[row_num][fields[col_num]]
    end
  end

module TopicDecorator
  def permalink
    "#{id}-#{title}"
  end
end

topics =
  100.times.map do |i|
    id = rand(1..9999)
    {
      id: id,
      title: "topic #{id}",
    }
  end
result = PgResult.new(topics)

materialized = MiniSql::Postgres::Connection.default_deserializer_cache.materialize(result, TopicDecorator)

Benchmark.ips do |r|
  r.report("to_json") do
    MiniSql::Serializer.to_json(materialized)
  end
  r.report("to_json_compacted") do
    MiniSql::Serializer.to_json_compacted(materialized)
  end
  r.compare!
end

json = MiniSql::Serializer.to_json(materialized)
json_compacted = MiniSql::Serializer.to_json_compacted(materialized)

Benchmark.ips do |r|
  r.report("Serializer.from_json") do
    MiniSql::Serializer.from_json(json)
  end
  r.report("Serializer.from_json_compacted") do
    MiniSql::Serializer.from_json_compacted(json_compacted)
  end
  r.compare!
end

# Warming up --------------------------------------
#              to_json   279.000  i/100ms
#    to_json_compacted     1.312k i/100ms
# Calculating -------------------------------------
#              to_json      2.760k (± 1.2%) i/s -     13.950k in   5.055071s
#    to_json_compacted     13.174k (± 1.4%) i/s -     66.912k in   5.080257s

# Comparison:
#    to_json_compacted:    13173.5 i/s
#              to_json:     2760.0 i/s - 4.77x  (± 0.00) slower

# Warming up --------------------------------------
# Serializer.from_json   562.000  i/100ms
# Serializer.from_json_compacted
#                          1.186k i/100ms
# Calculating -------------------------------------
# Serializer.from_json      5.491k (± 2.3%) i/s -     27.538k in   5.017606s
# Serializer.from_json_compacted
#                          11.615k (± 1.9%) i/s -     58.114k in   5.005099s

# Comparison:
# Serializer.from_json_compacted:    11615.3 i/s
# Serializer.from_json:     5491.2 i/s - 2.12x  (± 0.00) slower
```