### PR TITLE
Marshallable fix

### DIFF
--- a/lib/mini_sql/serializer.rb
+++ b/lib/mini_sql/serializer.rb
@@ -12,12 +12,12 @@ module MiniSql
       new(result)
     end
 
-    def _dump(level)
-      JSON.generate(serialize)
+    def marshal_dump
+      serialize
     end
 
-    def self._load(dump)
-      materialize(JSON.parse(dump))
+    def marshal_load(wrapper)
+      replace self.class.materialize(wrapper)
     end
 
     private

--- a/test/mini_sql/connection_tests.rb
+++ b/test/mini_sql/connection_tests.rb
@@ -152,12 +152,13 @@ module MiniSql::ConnectionTests
   end
 
   def test_serializer_marshal
-    r = @connection.query("select 1 one, 'two' two")
+    r = @connection.query("select 1 one, 'two' two, 'now'::date today")
     dump = Marshal.dump(MiniSql::Serializer.marshallable(r))
     r = Marshal.load(dump)
 
     assert_equal(r[0].one, 1)
     assert_equal(r[0].two, "two")
+    assert_equal(r[0].today, Date.today)
     assert_equal(r.length, 1)
   end
 


### PR DESCRIPTION
Marshal's `_dump`/`_load` with JSON `parse`/`generate` works incorrect (same as plain JSON). Sorry, my mistake, doesn't checked.

```ruby
# frozen_string_literal: true

require 'json'
require 'date'

class SerializeDateJson
  attr_reader :date

  def initialize(date)
    @date = date
  end

  def _dump(level)
    JSON.generate(date)
  end

  def self._load(dump)
    SerializeDateJson.new(JSON.parse(dump))
  end
end

json_dump = Marshal.dump(SerializeDateJson.new(Date.today))
p Marshal.load(json_dump).date
# "2021-02-03"
```