### PR TITLE
Results equality

### DIFF
--- a/lib/mini_sql/result.rb
+++ b/lib/mini_sql/result.rb
@@ -16,5 +16,15 @@ module MiniSql
     def values
       instance_variables.map { |f| instance_variable_get(f) }
     end
+
+    def ==(other_result)
+      self.class.decorator == other_result.class.decorator && 
+      self.instance_variables == other_result.instance_variables &&
+      self.values == other_result.values
+    end
+
+    def eql?(other_result)
+      self == other_result
+    end
   end
 end

--- a/lib/mini_sql/result.rb
+++ b/lib/mini_sql/result.rb
@@ -18,7 +18,7 @@ module MiniSql
     end
 
     def ==(other_result)
-      self.class.decorator == other_result.class.decorator && 
+      self.class.decorator == other_result.class.decorator &&
       self.instance_variables == other_result.instance_variables &&
       self.values == other_result.values
     end

--- a/test/mini_sql/connection_tests.rb
+++ b/test/mini_sql/connection_tests.rb
@@ -188,14 +188,21 @@ module MiniSql::ConnectionTests
     assert_equal([r1] | [r2], [r1])
   end
 
-  def test_equality_different_fields
+  def test_equality_mixed
+    r1 = @connection.query('select 20 price, 3 quantity')
+    r2 = @connection.query_decorator(ProductDecorator, 'select 20 price, 3 quantity')
+
+    assert r1 != r2
+  end
+
+  def test_equality_distinct_fields
     r1 = @connection.query("select 1 one, 'two' two, 3 three")
     r2 = @connection.query("select 1 one, 'two' two")
 
     assert r1 != r2
   end
 
-  def test_equality_different_values
+  def test_equality_distinct_values
     r1 = @connection.query("select 1 one, 'two' two")
     r2 = @connection.query("select 1 one, 2 two")
 

--- a/test/mini_sql/connection_tests.rb
+++ b/test/mini_sql/connection_tests.rb
@@ -193,6 +193,7 @@ module MiniSql::ConnectionTests
     r2 = @connection.query_decorator(ProductDecorator, 'select 20 price, 3 quantity')
 
     assert r1 != r2
+    assert_equal([r1] | [r2], [r1] + [r2])
   end
 
   def test_equality_distinct_fields

--- a/test/mini_sql/connection_tests.rb
+++ b/test/mini_sql/connection_tests.rb
@@ -172,4 +172,34 @@ module MiniSql::ConnectionTests
     assert_equal(r.length, 1)
   end
 
+  def test_equality
+    r1 = @connection.query("select 1 one, 'two' two")
+    r2 = @connection.query("select 1 one, 'two' two")
+
+    assert_equal(r1, r2)
+    assert_equal([r1] | [r2], [r1])
+  end
+
+  def test_equality_with_decorator
+    r1 = @connection.query_decorator(ProductDecorator, 'select 20 price, 3 quantity')
+    r2 = @connection.query_decorator(ProductDecorator, 'select 20 price, 3 quantity')
+
+    assert_equal(r1, r2)
+    assert_equal([r1] | [r2], [r1])
+  end
+
+  def test_equality_different_fields
+    r1 = @connection.query("select 1 one, 'two' two, 3 three")
+    r2 = @connection.query("select 1 one, 'two' two")
+
+    assert r1 != r2
+  end
+
+  def test_equality_different_values
+    r1 = @connection.query("select 1 one, 'two' two")
+    r2 = @connection.query("select 1 one, 2 two")
+
+    assert r1 != r2
+  end
+
 end


### PR DESCRIPTION
In production code we have something like this:

```ruby
landing_products = DB.query('SELECT id, title FROM products where is_landing = true')
...
products = landing_products | similar_produts | popuplar_products
```

The PR removes duplicates from `products`