### PR TITLE
Improve performance while caching materializers

### DIFF
--- a/lib/mini_sql/mysql/deserializer_cache.rb
+++ b/lib/mini_sql/mysql/deserializer_cache.rb
@@ -15,13 +15,12 @@ module MiniSql
         key = result.fields
 
         # trivial fast LRU implementation
-        materializer = @cache.delete(key)
-        if materializer
-          @cache[key] = materializer
-        else
-          materializer = @cache[key] = new_row_matrializer(result)
-          @cache.shift if @cache.length > @max_size
-        end
+        materializer = @cache[key] ||
+          begin
+            _materializer = @cache[key] = new_row_matrializer(result)
+            @cache.shift if @cache.length > @max_size
+            _materializer
+          end
 
         if decorator_module
           materializer = materializer.decorated(decorator_module)

--- a/lib/mini_sql/postgres/deserializer_cache.rb
+++ b/lib/mini_sql/postgres/deserializer_cache.rb
@@ -14,13 +14,12 @@ module MiniSql
       def materializer(result)
         key = result.fields
 
-        materializer = @cache.delete(key)
-        if materializer
-          @cache[key] = materializer
-        else
-          materializer = @cache[key] = new_row_matrializer(result)
-          @cache.shift if @cache.length > @max_size
-        end
+        materializer = @cache[key] ||
+          begin
+            _materializer = @cache[key] = new_row_matrializer(result)
+            @cache.shift if @cache.length > @max_size
+            _materializer
+          end
 
         materializer
       end
@@ -31,13 +30,12 @@ module MiniSql
         key = result.fields
 
         # trivial fast LRU implementation
-        materializer = @cache.delete(key)
-        if materializer
-          @cache[key] = materializer
-        else
-          materializer = @cache[key] = new_row_matrializer(result)
-          @cache.shift if @cache.length > @max_size
-        end
+        materializer = @cache[key] ||
+          begin
+            _materializer = @cache[key] = new_row_matrializer(result)
+            @cache.shift if @cache.length > @max_size
+            _materializer
+          end
 
         if decorator_module
           materializer = materializer.decorated(decorator_module)

--- a/lib/mini_sql/postgres_jdbc/deserializer_cache.rb
+++ b/lib/mini_sql/postgres_jdbc/deserializer_cache.rb
@@ -18,13 +18,12 @@ module MiniSql
         key = result.fields
 
         # trivial fast LRU implementation
-        materializer = @cache.delete(key)
-        if materializer
-          @cache[key] = materializer
-        else
-          materializer = @cache[key] = new_row_matrializer(result)
-          @cache.shift if @cache.length > @max_size
-        end
+        materializer = @cache[key] ||
+          begin
+            _materializer = @cache[key] = new_row_matrializer(result)
+            @cache.shift if @cache.length > @max_size
+            _materializer
+          end
 
         materializer.include(decorator_module) if decorator_module
 

--- a/lib/mini_sql/serializer.rb
+++ b/lib/mini_sql/serializer.rb
@@ -48,13 +48,12 @@ module MiniSql
     def self.cached_materializer(fields, decorator_module = nil)
       @cache ||= {}
       key = fields
-      m = @cache.delete(key)
-      if m
-        @cache[key] = m
-      else
-        m = @cache[key] = materializer(fields)
-        @cache.shift if @cache.length > MAX_CACHE_SIZE
-      end
+      m = @cache[key] ||
+        begin
+          _m = @cache[key] = materializer(fields)
+          @cache.shift if @cache.length > MAX_CACHE_SIZE
+          _m
+        end
 
       if decorator_module && decorator_module.length > 0
         decorator = Kernel.const_get(decorator_module)

--- a/lib/mini_sql/sqlite/deserializer_cache.rb
+++ b/lib/mini_sql/sqlite/deserializer_cache.rb
@@ -16,13 +16,12 @@ module MiniSql
         key = result.columns
 
         # trivial fast LRU implementation
-        materializer = @cache.delete(key)
-        if materializer
-          @cache[key] = materializer
-        else
-          materializer = @cache[key] = new_row_matrializer(result)
-          @cache.shift if @cache.length > @max_size
-        end
+        materializer = @cache[key] ||
+          begin
+            _materializer = @cache[key] = new_row_matrializer(result)
+            @cache.shift if @cache.length > @max_size
+            _materializer
+          end
 
         if decorator_module
           materializer = materializer.decorated(decorator_module)


### PR DESCRIPTION
With this small change we gain a bit performance. See the results of a sandbox (for a happy path only) profiling:

```ruby
require 'benchmark/ips'

@cache = {
  x: 1,
  y: 2,
  z: 3
}

GC.disable

def old_call
  key = :x
  m = @cache.delete(key)
  @cache[key] = m
  m
end

def new_call
  key = :x
  m = @cache[key] || 0
  m
end

Benchmark.ips do |x|
  x.report(:old) do
    old_call
  end
  x.report(:new) do
    new_call
  end
  x.compare!
end
```

```
Warming up --------------------------------------
                 old   685.254k i/100ms
                 new     1.070M i/100ms
Calculating -------------------------------------
                 old      6.721M (± 2.9%) i/s -     33.577M in   5.000392s
                 new     10.486M (± 1.1%) i/s -     52.426M in   5.000098s

Comparison:
                 new: 10486303.5 i/s
                 old:  6721441.8 i/s - 1.56x  (± 0.00) slower
```