### PR TITLE
FEATURE: Add ActiveRecordPostgres connection

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,9 @@
-2022-31-01 - 1.2.0
+2022-02-02 - 1.3.0
+
+- FEATURE: Add ActiveRecordPostgres connection
+  This is almost identical to the Postgres connection, but will acquire ActiveRecord's connection lock for each query
+
+2022-01-31 - 1.2.0
 
 - Ruby 2.6 is EOL support removed
 - FIX: when multiple params shared a prefix inline encoder may work in unexpected ways

--- a/README.md
+++ b/README.md
@@ -241,6 +241,17 @@ builder.where("id IN (?)", ids)
 builder.prepared(ids.size == 1).query # most frequent query
 ```
 
+## Active Record Postgres
+
+When using alongside ActiveRecord, passing in the ActiveRecord connection rather than the raw Postgres connection will allow mini_sql to lock the connection, thereby preventing concurrent use in other threads.
+
+```ruby
+ar_conn = ActiveRecord::Base.connection
+conn = MiniSql::Connection.get(ar_conn)
+
+conn.query("select * from topics")
+```
+
 ## I want more features!
 
 MiniSql is designed to be very minimal. Even though the query builder and type materializer give you a lot of mileage, it is not intended to be a fully fledged ORM. If you are looking for an ORM I recommend investigating ActiveRecord or Sequel which provide significantly more features.

--- a/lib/mini_sql.rb
+++ b/lib/mini_sql.rb
@@ -31,6 +31,10 @@ module MiniSql
       autoload :PreparedBinds,      "mini_sql/postgres/prepared_binds"
     end
 
+    module ActiveRecordPostgres
+      autoload :Connection, "mini_sql/active_record_postgres/connection"
+    end
+
     module Sqlite
       autoload :Connection,         "mini_sql/sqlite/connection"
       autoload :DeserializerCache,  "mini_sql/sqlite/deserializer_cache"

--- a/lib/mini_sql/active_record_postgres/connection.rb
+++ b/lib/mini_sql/active_record_postgres/connection.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module MiniSql
+  module ActiveRecordPostgres
+    class Connection < ::MiniSql::Postgres::Connection
+      attr_reader :active_record_connection
+
+      # Initialize a new MiniSql::Postgres::Connection object
+      #
+      # @param active_record_adapter [ActiveRecord::ConnectionAdapters::PostgresqlAdapter]
+      # @param deserializer_cache [MiniSql::DeserializerCache] a cache of field names to deserializer, can be nil
+      # @param type_map [PG::TypeMap] a type mapper for all results returned, can be nil
+      def initialize(active_record_adapter, args = nil)
+        @active_record_connection = active_record_adapter
+        super(nil, args)
+      end
+
+      def raw_connection
+        active_record_connection.raw_connection
+      end
+
+      # These two methods do not use `run`, so we need to apply
+      # the lock separately:
+      def query_each(sql, *params)
+        with_lock { super }
+      end
+      def query_each_hash(sql, *params)
+        with_lock { super }
+      end
+
+      private
+
+      def with_lock
+        active_record_connection.lock.synchronize { yield }
+      end
+
+      def run(sql, params)
+        with_lock { super }
+      end
+    end
+  end
+end

--- a/lib/mini_sql/connection.rb
+++ b/lib/mini_sql/connection.rb
@@ -6,6 +6,8 @@ module MiniSql
     def self.get(raw_connection, options = {})
       if (defined? ::PG::Connection) && (PG::Connection === raw_connection)
         Postgres::Connection.new(raw_connection, options)
+      elsif (defined? ActiveRecord::ConnectionAdapters::PostgreSQLAdapter) && (ActiveRecord::ConnectionAdapters::PostgreSQLAdapter === raw_connection)
+        ActiveRecordPostgres::Connection.new(raw_connection, options)
       elsif (defined? ::ArJdbc)
         Postgres::Connection.new(raw_connection, options)
       elsif (defined? ::SQLite3::Database) && (SQLite3::Database === raw_connection)

--- a/lib/mini_sql/version.rb
+++ b/lib/mini_sql/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module MiniSql
-  VERSION = "1.2.0"
+  VERSION = "1.3.0"
 end

--- a/mini_sql.gemspec
+++ b/mini_sql.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "guard", "~> 2.18"
   spec.add_development_dependency "guard-minitest", "~> 2.4"
-  spec.add_development_dependency "activesupport", "~> 5.2"
+  spec.add_development_dependency "activesupport", "~> 7.0"
   spec.add_development_dependency 'rubocop', '~> 1.25.0'
   spec.add_development_dependency 'rubocop-discourse', '~> 2.5.0'
   spec.add_development_dependency 'm', '~> 1.6.0'
@@ -48,5 +48,6 @@ Gem::Specification.new do |spec|
     spec.add_development_dependency "pg", "> 1"
     spec.add_development_dependency "mysql2"
     spec.add_development_dependency "sqlite3", "~> 1.3"
+    spec.add_development_dependency "activerecord", "~> 7.0.0"
   end
 end

--- a/test/mini_sql/active_record_postgres/connection_test.rb
+++ b/test/mini_sql/active_record_postgres/connection_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class MiniSql::ActiveRecordPostgres::TestConnection < MiniTest::Test
+  def setup
+    @connection = active_record_pg_connection
+  end
+
+  def new_connection(opts = {})
+    active_record_pg_connection(opts)
+  end
+
+  include MiniSql::ConnectionTests
+
+  def test_simple_query_locking
+    start_time = Time.now
+    active_record_connection = @connection.active_record_connection
+    raw_pg_connection = active_record_connection.raw_connection
+
+    t = Thread.new do
+      @connection.query("SELECT pg_sleep(5)")
+    rescue PG::QueryCanceled
+      # Expected
+    end
+
+    Thread.pass until active_record_connection.lock.mon_locked?
+
+    assert(start_time > 5.seconds.ago, "Locked the mutex while running the query")
+
+    raw_pg_connection.cancel()
+
+    Thread.pass until !active_record_connection.lock.mon_locked?
+
+    assert(start_time > 5.seconds.ago, "Unlocked the mutex when the query finished")
+
+    t.join
+  end
+
+  def test_query_each_locking
+    active_record_connection = @connection.active_record_connection
+
+    query = "select 1 a, 2 b union all select 3,4 union all select 5,6"
+    rows = []
+    @connection.query_each(query) do |row|
+      assert(active_record_connection.lock.mon_locked?)
+    end
+
+    assert(!active_record_connection.lock.mon_locked?)
+
+    @connection.query_each_hash(query) do |row|
+      assert(active_record_connection.lock.mon_locked?)
+    end
+
+    assert(!active_record_connection.lock.mon_locked?)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,6 +21,7 @@ else
   require "pg"
   require "sqlite3"
   require "mysql2"
+  require 'active_record'
 
   def mysql_connection(options = {})
     args = { database: 'test_mini_sql', username: 'root', password: '' }
@@ -44,6 +45,17 @@ else
     end
     pg_conn = PG.connect(**args)
     MiniSql::Connection.get(pg_conn, options)
+  end
+
+  def active_record_pg_connection(options = {})
+    args = { adapter: 'postgresql', dbname: 'test_mini_sql' }
+    %i[port host password user].each do |name|
+      if val = ENV["MINI_SQL_PG_#{name.upcase}"]
+        args[name] = val
+      end
+    end
+    ar_conn = ActiveRecord::Base.establish_connection(**args).checkout
+    MiniSql::Connection.get(ar_conn, options)
   end
 
   def sqlite3_connection(options = {})


### PR DESCRIPTION
This is almost identical to the Postgres connection, but will acquire ActiveRecord's connection lock for each query.

Example usage at https://github.com/discourse/discourse/pull/15767