### PR TITLE
speedup DeserializerCache

### DIFF
--- a/lib/mini_sql/mysql/deserializer_cache.rb
+++ b/lib/mini_sql/mysql/deserializer_cache.rb
@@ -12,7 +12,7 @@ module MiniSql
       end
 
       def materialize(result, decorator_module = nil)
-        key = result.fields
+        key = result.fields.join(',')
 
         # trivial fast LRU implementation
         materializer = @cache.delete(key)

--- a/lib/mini_sql/postgres/deserializer_cache.rb
+++ b/lib/mini_sql/postgres/deserializer_cache.rb
@@ -12,7 +12,7 @@ module MiniSql
       end
 
       def materializer(result)
-        key = result.fields
+        key = result.fields.join(',')
 
         materializer = @cache.delete(key)
         if materializer
@@ -28,7 +28,7 @@ module MiniSql
       def materialize(result, decorator_module = nil)
         return [] if result.ntuples == 0
 
-        key = result.fields
+        key = result.fields.join(',')
 
         # trivial fast LRU implementation
         materializer = @cache.delete(key)

--- a/lib/mini_sql/postgres_jdbc/deserializer_cache.rb
+++ b/lib/mini_sql/postgres_jdbc/deserializer_cache.rb
@@ -15,7 +15,7 @@ module MiniSql
 
         return [] if result.ntuples == 0
 
-        key = result.fields
+        key = result.fields.join(',')
 
         # trivial fast LRU implementation
         materializer = @cache.delete(key)

--- a/lib/mini_sql/sqlite/deserializer_cache.rb
+++ b/lib/mini_sql/sqlite/deserializer_cache.rb
@@ -13,7 +13,7 @@ module MiniSql
 
       def materialize(result, decorator_module = nil)
 
-        key = result.columns
+        key = result.columns.join(',')
 
         # trivial fast LRU implementation
         materializer = @cache.delete(key)


### PR DESCRIPTION
```ruby
module MiniSql
  module Postgres
    class DeserializerCache
      def materialize(result, decorator_module: nil, str_key:)
        return [] if result.ntuples == 0

        key = str_key ? result.fields.join(',') : result.fields # ADDED

        # trivial fast LRU implementation
        materializer = @cache.delete(key)
        if materializer
          @cache[key] = materializer
        else
          materializer = @cache[key] = new_row_materializer(result)
          @cache.shift if @cache.length > @max_size
        end

        if decorator_module
          materializer = materializer.decorated(decorator_module)
        end

        i = 0
        r = []
        # quicker loop
        while i < result.ntuples
          r << materializer.materialize(result, i)
          i += 1
        end
        r
      end
    end
  end
end

PgResult =
  Struct.new(:rows) do
    def ntuples
      rows.size
    end

    def fields
      @fields ||= rows[0].keys
    end

    def getvalue(row_num, col_num)
      rows[row_num][fields[col_num]]
    end
  end

result = PgResult.new([{
  'id' => 1,
  'title' => "topic",
  'title1' => "topic 1",
  'title2' => "topic 2",
  'title3' => "topic 3",
}])

d = MiniSql::Postgres::Connection.default_deserializer_cache

Benchmark.ips do |r|
  r.report('str key') do |n|
    while n > 0
      d.materialize(result, str_key: true)
      n -= 1
    end
  end
  r.report('array key') do |n|
    while n > 0
      d.materialize(result, str_key: false)
      n -= 1
    end
  end

  r.compare!
end

# Comparison:
#              str key:   382708.2 i/s
#            array key:   219753.9 i/s - 1.74x  (± 0.00) slower
```

```ruby
[5, 30].each do |size_keys|
  keys = size_keys.times.map { |i| "user_id#{1}" };
  h = {}

  Benchmark.ips do |x|
    x.report("array #{size_keys}") do |n|
      while n > 0
        h[keys] = 1
        h.delete(keys)
        n-=1
      end
    end
    x.report("join #{size_keys}") do |n|
      while n > 0
        c = keys.join(',')
        h[c] = 1
        h.delete(c)
        n-=1
      end
    end

    x.compare!
  end
end;


# Comparison:
#               join 5:  1102518.0 i/s
#              array 5:   351877.1 i/s - 3.13x  (± 0.00) slower
#
# Comparison:
#              join 30:   308413.5 i/s
#             array 30:    72966.5 i/s - 4.23x  (± 0.00) slower
```