### PR TITLE
FEATURE: Decoder for pgvector

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
   export MINI_SQL_MYSQL_HOST=127.0.0.1
   export MINI_SQL_MYSQL_PORT=33306
   
-  docker run --name mini-sql-postgres --rm -it -p 55432:5432 -e POSTGRES_DB=test_mini_sql -e POSTGRES_HOST_AUTH_METHOD=trust -d postgres
+  docker run --name mini-sql-postgres --rm -it -p 55432:5432 -e POSTGRES_DB=test_mini_sql -e POSTGRES_HOST_AUTH_METHOD=trust -d postgres # or ankane/pgvector for testing vector type decoder
   export MINI_SQL_PG_USER=postgres
   export MINI_SQL_PG_HOST=127.0.0.1
   export MINI_SQL_PG_PORT=55432

--- a/lib/mini_sql/postgres/connection.rb
+++ b/lib/mini_sql/postgres/connection.rb
@@ -26,6 +26,20 @@ module MiniSql
             else
               map.add_coder(MiniSql::Postgres::Coders::TimestampUtc.new(name: "timestamp", oid: 1114, format: 0))
             end
+
+            if defined? Pgvector::PG
+              vector_oid =
+                PG::BasicTypeRegistry::CoderMapsBundle
+                  .new(conn)
+                  .typenames_by_oid
+                  .find { |k, v| v == "vector" }
+                  &.first
+
+              if !vector_oid.nil?
+                map.add_coder(Pgvector::PG::TextDecoder::Vector.new(name: "vector", oid: vector_oid, format: 0))
+                map.add_coder(Pgvector::PG::BinaryDecoder::Vector.new(name: "vector", oid: vector_oid, format: 1))
+              end
+            end
             map
           end
       end

--- a/mini_sql.gemspec
+++ b/mini_sql.gemspec
@@ -49,5 +49,8 @@ Gem::Specification.new do |spec|
     spec.add_development_dependency "mysql2"
     spec.add_development_dependency "sqlite3", "~> 1.4.4"
     spec.add_development_dependency "activerecord", "~> 7.0.0"
+    if RUBY_VERSION >= "3.0"
+      spec.add_development_dependency "pgvector", "~> 0.2.1"
+    end
   end
 end


### PR DESCRIPTION
This PR adds automatic decoding of the pgvector `vector` column type into Ruby float arrays only if your project also imports the `pgvector` gem, where the decoders definition live.

With this change logs will not have instances of the below warning

```
Warning: no type cast defined for type "vector" format 0 with oid 16391. Please cast this type explicitly to TEXT to be safe for future changes.
```

