### PR TITLE
[prepared statements] fix for auto_encode_arrays, refactoring

### DIFF
--- a/lib/mini_sql.rb
+++ b/lib/mini_sql.rb
@@ -29,6 +29,7 @@ module MiniSql
       autoload :PreparedConnection, "mini_sql/postgres/prepared_connection"
       autoload :PreparedCache,      "mini_sql/postgres/prepared_cache"
       autoload :PreparedBinds,      "mini_sql/postgres/prepared_binds"
+      autoload :PreparedBindsAutoArray, "mini_sql/postgres/prepared_binds_auto_array"
     end
 
     module ActiveRecordPostgres

--- a/lib/mini_sql/abstract/prepared_binds.rb
+++ b/lib/mini_sql/abstract/prepared_binds.rb
@@ -41,13 +41,12 @@ module MiniSql
 
       def bind_array(sql, array)
         sql = sql.dup
-        param_i = 0
+        param_i = -1
         i = 0
         binds = []
         bind_names = []
         sql.gsub!("?") do
-          param_i += 1
-          array_wrap(array[param_i - 1]).map do |vv|
+          array_wrap(array[param_i += 1]).map do |vv|
             binds << vv
             i += 1
             bind_names << [BindName.new("$#{i}")]

--- a/lib/mini_sql/abstract/prepared_cache.rb
+++ b/lib/mini_sql/abstract/prepared_cache.rb
@@ -14,7 +14,7 @@ module MiniSql
       end
 
       def prepare_statement(sql)
-        stm_key = "#{@connection.object_id}-#{sql}"
+        stm_key = "#{raw_connection.object_id}-#{sql}"
         statement = @cache.delete(stm_key)
         if statement
           @cache[stm_key] = statement
@@ -27,6 +27,10 @@ module MiniSql
       end
 
       private
+
+      def raw_connection
+        @connection.raw_connection
+      end
 
       def next_key
         "s#{@counter += 1}"

--- a/lib/mini_sql/builder.rb
+++ b/lib/mini_sql/builder.rb
@@ -70,9 +70,8 @@ class MiniSql::Builder
     connection_switcher.query_decorator(decorator, parametrized_sql, union_parameters(hash_args))
   end
 
-  def prepared(condition = true)
-    @is_prepared = condition
-
+  def prepared
+    @is_prepared = true
     self
   end
 

--- a/lib/mini_sql/inline_param_encoder.rb
+++ b/lib/mini_sql/inline_param_encoder.rb
@@ -51,19 +51,21 @@ module MiniSql
       value.utc.iso8601
     end
 
+    EMPTY_ARRAY = [].freeze
+
     def quote_val(value)
       case value
-      when String     then "'#{conn.escape_string(value.to_s)}'"
-      when Numeric    then value.to_s
-      when BigDecimal then value.to_s("F")
-      when Time       then "'#{quoted_time(value)}'"
-      when Date       then "'#{value.to_s}'"
-      when Symbol     then "'#{conn.escape_string(value.to_s)}'"
-      when true       then "true"
-      when false      then "false"
-      when nil        then "NULL"
-      when []         then "NULL"
-      when Array      then array_encoder ? "'#{array_encoder.encode(value)}'" : value.map { |v| quote_val(v) }.join(', ')
+      when String       then "'#{conn.escape_string(value.to_s)}'"
+      when Numeric      then value.to_s
+      when BigDecimal   then value.to_s("F")
+      when Time         then "'#{quoted_time(value)}'"
+      when Date         then "'#{value.to_s}'"
+      when Symbol       then "'#{conn.escape_string(value.to_s)}'"
+      when true         then "true"
+      when false        then "false"
+      when nil          then "NULL"
+      when EMPTY_ARRAY  then array_encoder ? "{}" : "NULL"
+      when Array        then array_encoder ? "'#{array_encoder.encode(value)}'" : value.map { |v| quote_val(v) }.join(', ')
       else raise TypeError, "can't quote #{value.class.name}"
       end
     end

--- a/lib/mini_sql/inline_param_encoder.rb
+++ b/lib/mini_sql/inline_param_encoder.rb
@@ -64,7 +64,7 @@ module MiniSql
       when true         then "true"
       when false        then "false"
       when nil          then "NULL"
-      when EMPTY_ARRAY  then array_encoder ? "{}" : "NULL"
+      when EMPTY_ARRAY  then array_encoder ? "'{}'" : "NULL"
       when Array        then array_encoder ? "'#{array_encoder.encode(value)}'" : value.map { |v| quote_val(v) }.join(', ')
       else raise TypeError, "can't quote #{value.class.name}"
       end

--- a/lib/mini_sql/mysql/connection.rb
+++ b/lib/mini_sql/mysql/connection.rb
@@ -11,12 +11,8 @@ module MiniSql
         @deserializer_cache = (args && args[:deserializer_cache]) || DeserializerCache.new
       end
 
-      def prepared(condition = true)
-        if condition
-          @prepared ||= PreparedConnection.new(self)
-        else
-          self
-        end
+      def prepared
+        @prepared ||= PreparedConnection.new(self)
       end
 
       def query_single(sql, *params)

--- a/lib/mini_sql/mysql/prepared_cache.rb
+++ b/lib/mini_sql/mysql/prepared_cache.rb
@@ -9,7 +9,7 @@ module MiniSql
       private
 
       def alloc(sql)
-        @connection.prepare(sql)
+        raw_connection.prepare(sql)
       end
 
       def dealloc(statement)

--- a/lib/mini_sql/mysql/prepared_connection.rb
+++ b/lib/mini_sql/mysql/prepared_connection.rb
@@ -15,9 +15,7 @@ module MiniSql
         raise 'Builder can not be called on prepared connections, instead of `::MINI_SQL.prepared.build(sql).query` use `::MINI_SQL.build(sql).prepared.query`'
       end
 
-      def prepared(condition = true)
-        condition ? self : @unprepared
-      end
+      undef_method :prepared
 
       def deserializer_cache
         @unprepared.deserializer_cache

--- a/lib/mini_sql/mysql/prepared_connection.rb
+++ b/lib/mini_sql/mysql/prepared_connection.rb
@@ -7,12 +7,8 @@ module MiniSql
       attr_reader :unprepared
 
       def initialize(unprepared_connection)
-        @unprepared         = unprepared_connection
-        @raw_connection     = unprepared_connection.raw_connection
-        @param_encoder      = unprepared_connection.param_encoder
-
-        @prepared_cache     = PreparedCache.new(@raw_connection)
-        @param_binder       = PreparedBinds.new
+        @unprepared    = unprepared_connection
+        @param_binder  = PreparedBinds.new
       end
 
       def build(_)
@@ -29,6 +25,8 @@ module MiniSql
 
       private def run(sql, as, params)
         prepared_sql, binds, _bind_names = @param_binder.bind(sql, *params)
+
+        @prepared_cache ||= PreparedCache.new(unprepared)
         statement = @prepared_cache.prepare_statement(prepared_sql)
         statement.execute(
           *binds,

--- a/lib/mini_sql/postgres/connection.rb
+++ b/lib/mini_sql/postgres/connection.rb
@@ -61,12 +61,8 @@ module MiniSql
         @type_map ||= self.class.type_map(raw_connection)
       end
 
-      def prepared(condition = true)
-        if condition
-          @prepared ||= PreparedConnection.new(self)
-        else
-          self
-        end
+      def prepared
+        @prepared ||= PreparedConnection.new(self)
       end
 
       # Returns a flat array containing all results.

--- a/lib/mini_sql/postgres/connection.rb
+++ b/lib/mini_sql/postgres/connection.rb
@@ -3,7 +3,7 @@
 module MiniSql
   module Postgres
     class Connection < MiniSql::Connection
-      attr_reader :raw_connection, :param_encoder, :deserializer_cache
+      attr_reader :raw_connection, :param_encoder, :deserializer_cache, :array_encoder
 
       def self.default_deserializer_cache
         @deserializer_cache ||= DeserializerCache.new
@@ -52,7 +52,7 @@ module MiniSql
       def initialize(raw_connection, args = nil)
         @raw_connection = raw_connection
         @deserializer_cache = (args && args[:deserializer_cache]) || self.class.default_deserializer_cache
-        array_encoder = PG::TextEncoder::Array.new if args && args[:auto_encode_arrays]
+        @array_encoder = PG::TextEncoder::Array.new if args && args[:auto_encode_arrays]
         @param_encoder = (args && args[:param_encoder]) || InlineParamEncoder.new(self, array_encoder)
         @type_map = args && args[:type_map]
       end

--- a/lib/mini_sql/postgres/prepared_binds_auto_array.rb
+++ b/lib/mini_sql/postgres/prepared_binds_auto_array.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "mini_sql/abstract/prepared_binds"
+
+module MiniSql
+  module Postgres
+    class PreparedBindsAutoArray < ::MiniSql::Abstract::PreparedBinds
+
+      attr_reader :array_encoder
+
+      def initialize(array_encoder)
+        @array_encoder = array_encoder
+      end
+
+      def bind_hash(sql, hash)
+        sql = sql.dup
+        binds = []
+        bind_names = []
+        i = 0
+
+        hash.each do |k, v|
+          binds << (v.is_a?(Array) ? array_encoder.encode(v) : v)
+          bind_names << [BindName.new(k)]
+          bind_outputs = bind_output(i += 1)
+
+          sql.gsub!(":#{k}") do
+            # ignore ::int and stuff like that
+            # $` is previous to match
+            if $` && $`[-1] != ":"
+              bind_outputs
+            else
+              ":#{k}"
+            end
+          end
+        end
+        [sql, binds, bind_names]
+      end
+
+      def bind_array(sql, array)
+        sql = sql.dup
+        param_i = -1
+        i = 0
+        binds = []
+        bind_names = []
+        sql.gsub!("?") do
+          v = array[param_i += 1]
+          binds << (v.is_a?(Array) ? array_encoder.encode(v) : v)
+          i += 1
+          bind_names << [BindName.new("$#{i}")]
+          bind_output(i)
+        end
+        [sql, binds, bind_names]
+      end
+
+      def bind_output(i)
+        "$#{i}"
+      end
+
+    end
+  end
+end

--- a/lib/mini_sql/postgres/prepared_cache.rb
+++ b/lib/mini_sql/postgres/prepared_cache.rb
@@ -10,13 +10,13 @@ module MiniSql
 
       def alloc(sql)
         alloc_key = next_key
-        @connection.prepare(alloc_key, sql)
+        raw_connection.prepare(alloc_key, sql)
 
         alloc_key
       end
 
       def dealloc(key)
-        @connection.query "DEALLOCATE #{key}" if @connection.status == PG::CONNECTION_OK
+        raw_connection.query "DEALLOCATE #{key}" if raw_connection.status == PG::CONNECTION_OK
       rescue PG::Error
       end
 

--- a/lib/mini_sql/postgres/prepared_connection.rb
+++ b/lib/mini_sql/postgres/prepared_connection.rb
@@ -7,13 +7,9 @@ module MiniSql
       attr_reader :unprepared
 
       def initialize(unprepared_connection)
-        @unprepared         = unprepared_connection
-        @raw_connection     = unprepared_connection.raw_connection
-        @type_map           = unprepared_connection.type_map
-        @param_encoder      = unprepared_connection.param_encoder
-
-        @prepared_cache     = PreparedCache.new(@raw_connection)
-        @param_binder       = unprepared.array_encoder ? PreparedBindsAutoArray.new(unprepared.array_encoder) : PreparedBinds.new
+        @unprepared    = unprepared_connection
+        @type_map      = unprepared_connection.type_map
+        @param_binder  = unprepared.array_encoder ? PreparedBindsAutoArray.new(unprepared.array_encoder) : PreparedBinds.new
       end
 
       def build(_)
@@ -30,8 +26,9 @@ module MiniSql
 
       private def run(sql, params)
         prepared_sql, binds, _bind_names = @param_binder.bind(sql, *params)
+        @prepared_cache ||= PreparedCache.new(unprepared)
         prepare_statement_key = @prepared_cache.prepare_statement(prepared_sql)
-        raw_connection.exec_prepared(prepare_statement_key, binds)
+        unprepared.raw_connection.exec_prepared(prepare_statement_key, binds)
       end
 
     end

--- a/lib/mini_sql/postgres/prepared_connection.rb
+++ b/lib/mini_sql/postgres/prepared_connection.rb
@@ -16,9 +16,7 @@ module MiniSql
         raise 'Builder can not be called on prepared connections, instead of `::MINI_SQL.prepared.build(sql).query` use `::MINI_SQL.build(sql).prepared.query`'
       end
 
-      def prepared(condition = true)
-        condition ? self : @unprepared
-      end
+      undef_method :prepared
 
       def deserializer_cache
         @unprepared.deserializer_cache

--- a/lib/mini_sql/postgres/prepared_connection.rb
+++ b/lib/mini_sql/postgres/prepared_connection.rb
@@ -13,7 +13,7 @@ module MiniSql
         @param_encoder      = unprepared_connection.param_encoder
 
         @prepared_cache     = PreparedCache.new(@raw_connection)
-        @param_binder       = PreparedBinds.new
+        @param_binder       = unprepared.array_encoder ? PreparedBindsAutoArray.new(unprepared.array_encoder) : PreparedBinds.new
       end
 
       def build(_)

--- a/lib/mini_sql/sqlite/connection.rb
+++ b/lib/mini_sql/sqlite/connection.rb
@@ -11,12 +11,8 @@ module MiniSql
         @deserializer_cache = (args && args[:deserializer_cache]) || DeserializerCache.new
       end
 
-      def prepared(condition = true)
-        if condition
-          @prepared ||= PreparedConnection.new(self)
-        else
-          self
-        end
+      def prepared
+        @prepared ||= PreparedConnection.new(self)
       end
 
       def query_single(sql, *params)

--- a/lib/mini_sql/sqlite/prepared_cache.rb
+++ b/lib/mini_sql/sqlite/prepared_cache.rb
@@ -9,7 +9,7 @@ module MiniSql
       private
 
       def alloc(sql)
-        @connection.prepare(sql)
+        raw_connection.prepare(sql)
       end
 
       def dealloc(statement)

--- a/lib/mini_sql/sqlite/prepared_connection.rb
+++ b/lib/mini_sql/sqlite/prepared_connection.rb
@@ -7,12 +7,8 @@ module MiniSql
       attr_reader :unprepared
 
       def initialize(unprepared_connection)
-        @unprepared         = unprepared_connection
-        @raw_connection     = unprepared_connection.raw_connection
-        @param_encoder      = unprepared_connection.param_encoder
-
-        @prepared_cache     = PreparedCache.new(@raw_connection)
-        @param_binder       = PreparedBinds.new
+        @unprepared    = unprepared_connection
+        @param_binder  = PreparedBinds.new
       end
 
       def build(_)
@@ -29,6 +25,7 @@ module MiniSql
 
       private def run(sql, params)
         prepared_sql, binds, _bind_names = @param_binder.bind(sql, *params)
+        @prepared_cache ||= PreparedCache.new(unprepared)
         statement = @prepared_cache.prepare_statement(prepared_sql)
         statement.bind_params(binds)
         if block_given?

--- a/lib/mini_sql/sqlite/prepared_connection.rb
+++ b/lib/mini_sql/sqlite/prepared_connection.rb
@@ -15,9 +15,7 @@ module MiniSql
         raise 'Builder can not be called on prepared connections, instead of `::MINI_SQL.prepared.build(sql).query` use `::MINI_SQL.build(sql).prepared.query`'
       end
 
-      def prepared(condition = true)
-        condition ? self : @unprepared
-      end
+      undef_method :prepared
 
       def deserializer_cache
         @unprepared.deserializer_cache

--- a/test/mini_sql/connection_tests.rb
+++ b/test/mini_sql/connection_tests.rb
@@ -69,6 +69,8 @@ module MiniSql::ConnectionTests
   end
 
   def test_can_deal_with_arrays
+    return if @connection.respond_to?(:array_encoder) && @connection.array_encoder
+
     r = @connection.query_single("select :array as array", array: [1, 2, 3])
     assert_equal([1, 2, 3], r)
 

--- a/test/mini_sql/mysql/prepared_connection_test.rb
+++ b/test/mini_sql/mysql/prepared_connection_test.rb
@@ -7,9 +7,9 @@ class MiniSql::Mysql::TestPreparedConnection < Minitest::Test
 
   def setup
     @unprepared_connection = mysql_connection
-    @prepared_connection = @unprepared_connection.prepared
+    @connection = @unprepared_connection.prepared
 
-    super
+    setup_tables
 
     @unprepared_connection.exec("SET GLOBAL log_output = 'TABLE'")
     @unprepared_connection.exec("SET GLOBAL general_log = 'ON'")
@@ -28,7 +28,7 @@ class MiniSql::Mysql::TestPreparedConnection < Minitest::Test
   end
 
   def test_boolean_param
-    r = @prepared_connection.query("SELECT * FROM posts WHERE active = ?", true)
+    r = @connection.query("SELECT * FROM posts WHERE active = ?", true)
 
     assert_last_stmt "SELECT * FROM posts WHERE active = $1"
     assert_equal 2, r[0].id

--- a/test/mini_sql/postgres/auto_encode_arrays_test.rb
+++ b/test/mini_sql/postgres/auto_encode_arrays_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative 'connection_test'
+require_relative 'prepared_connection_test'
+
+module MiniSql::Postgres::ArrayTests
+  def test_simple_params
+    nums, strings, empty_array = [1, 2, 3], %w[a b c], []
+
+    row = @connection.query_single("select ?::int[], ?::text[], ?::int[]", nums, strings, empty_array)
+
+    assert_equal(row, [nums, strings, empty_array])
+  end
+
+  def test_hash_params
+    nums, strings, empty_array = [1, 2, 3], %w[a b c], []
+
+    row = @connection.query_single("select :nums::int[], :strings::text[], :empty_array::int[]", nums: nums, strings: strings, empty_array: empty_array)
+
+    assert_equal(row, [nums, strings, empty_array])
+  end
+end
+
+class MiniSql::Postgres::TestAutoEncodeArraysPrepared < MiniSql::Postgres::TestPreparedConnection
+  include MiniSql::Postgres::ArrayTests
+
+  def setup
+    @unprepared_connection = pg_connection(auto_encode_arrays: true)
+    @connection = @unprepared_connection.prepared
+
+    setup_tables
+  end
+end
+
+class MiniSql::Postgres::TestAutoEncodeArraysUnprepared < MiniSql::Postgres::TestConnection
+  include MiniSql::Postgres::ArrayTests
+
+  def setup
+    @connection = pg_connection(auto_encode_arrays: true)
+  end
+end

--- a/test/mini_sql/postgres/connection_test.rb
+++ b/test/mini_sql/postgres/connection_test.rb
@@ -161,7 +161,7 @@ class MiniSql::Postgres::TestConnection < Minitest::Test
     ints = [1, 2, 3]
     strings = %w[a b c]
     empty_array = []
-    row = connection.query("select ?::int[] ints, ?::text[] strings, ? empty_array", ints, strings, empty_array).first
+    row = connection.query("select ?::int[] ints, ?::text[] strings, ?::int[] empty_array", ints, strings, empty_array).first
 
     assert_equal(row.ints, ints)
     assert_equal(row.strings, strings)

--- a/test/mini_sql/postgres/connection_test.rb
+++ b/test/mini_sql/postgres/connection_test.rb
@@ -160,10 +160,12 @@ class MiniSql::Postgres::TestConnection < Minitest::Test
 
     ints = [1, 2, 3]
     strings = %w[a b c]
-    row = connection.query("select ?::int[] ints, ?::text[] strings", ints, strings).first
+    empty_array = []
+    row = connection.query("select ?::int[] ints, ?::text[] strings, ? empty_array", ints, strings, empty_array).first
 
     assert_equal(row.ints, ints)
     assert_equal(row.strings, strings)
+    assert_equal(row.empty_array, empty_array)
   end
 
 end

--- a/test/mini_sql/postgres/connection_test.rb
+++ b/test/mini_sql/postgres/connection_test.rb
@@ -155,26 +155,4 @@ class MiniSql::Postgres::TestConnection < Minitest::Test
     assert_equal(row.column2, 3)
   end
 
-  def test_array_with_auto_encode_arrays
-    connection = pg_connection(auto_encode_arrays: true)
-
-    ints = [1, 2, 3]
-    strings = %w[a b c]
-    empty_array = []
-    row = connection.query_single("select ?::int[], ?::text[], ?::int[]", ints, strings, empty_array)
-
-    assert_equal(row, [ints, strings, empty_array])
-  end
-
-  def test_simple_with_auto_encode_arrays
-    connection = pg_connection(auto_encode_arrays: true)
-
-    int = 1
-    str = "str"
-    date = Date.new(2020, 10, 10)
-    row = connection.query_single("select ?, ?, ?::date", int, str, date)
-
-    assert_equal(row, [int, str, date])
-  end
-
 end

--- a/test/mini_sql/postgres/connection_test.rb
+++ b/test/mini_sql/postgres/connection_test.rb
@@ -155,17 +155,26 @@ class MiniSql::Postgres::TestConnection < Minitest::Test
     assert_equal(row.column2, 3)
   end
 
-  def test_encode_array
+  def test_array_with_auto_encode_arrays
     connection = pg_connection(auto_encode_arrays: true)
 
     ints = [1, 2, 3]
     strings = %w[a b c]
     empty_array = []
-    row = connection.query("select ?::int[] ints, ?::text[] strings, ?::int[] empty_array", ints, strings, empty_array).first
+    row = connection.query_single("select ?::int[], ?::text[], ?::int[]", ints, strings, empty_array)
 
-    assert_equal(row.ints, ints)
-    assert_equal(row.strings, strings)
-    assert_equal(row.empty_array, empty_array)
+    assert_equal(row, [ints, strings, empty_array])
+  end
+
+  def test_simple_with_auto_encode_arrays
+    connection = pg_connection(auto_encode_arrays: true)
+
+    int = 1
+    str = "str"
+    date = Date.new(2020, 10, 10)
+    row = connection.query_single("select ?, ?, ?::date", int, str, date)
+
+    assert_equal(row, [int, str, date])
   end
 
 end

--- a/test/mini_sql/postgres/prepared_connection_test.rb
+++ b/test/mini_sql/postgres/prepared_connection_test.rb
@@ -62,14 +62,11 @@ class MiniSql::Postgres::TestPreparedConnection < Minitest::Test
   end
 
   def test_limit_prepared_cache
-    @prepared_connection.instance_variable_get(
-      :@prepared_cache
-    ).instance_variable_set(:@max_size, 1)
+    @prepared_connection.instance_variable_set(:@prepared_cache, MiniSql::Postgres::PreparedCache.new(@unprepared_connection, 1))
 
     assert_equal @prepared_connection.query_single("SELECT ?", 1), %w[1]
     assert_equal @prepared_connection.query_single("SELECT ?, ?", 1, 2), %w[1 2]
-    assert_equal @prepared_connection.query_single("SELECT ?, ?, ?", 1, 2, 3),
-                 %w[1 2 3]
+    assert_equal @prepared_connection.query_single("SELECT ?, ?, ?", 1, 2, 3), %w[1 2 3]
 
     ps = @unprepared_connection.query("select * from pg_prepared_statements")
     assert_equal ps.size, 1

--- a/test/mini_sql/postgres/prepared_connection_test.rb
+++ b/test/mini_sql/postgres/prepared_connection_test.rb
@@ -82,4 +82,37 @@ class MiniSql::Postgres::TestPreparedConnection < Minitest::Test
     assert_last_stmt "select $1, $1, $1"
     assert_equal %w[test test test], r
   end
+
+  def test_array_with_auto_encode_arrays
+    connection = pg_connection(auto_encode_arrays: true).prepared
+
+    ints = [1, 2, 3]
+    strings = %w[a b c]
+    empty_array = []
+    row = connection.query_single("select ?::int[], ?::text[], ?::int[]", ints, strings, empty_array)
+
+    assert_equal(row, [ints, strings, empty_array])
+  end
+
+  def test_simple_with_auto_encode_arrays
+    connection = pg_connection(auto_encode_arrays: true).prepared
+
+    int = 1
+    str = "str"
+    date = Date.new(2020, 10, 10)
+    row = connection.query_single("select ?::int, ?, ?::date", int, str, date)
+
+    assert_equal(row, [int, str, date])
+  end
+
+  def test_hash_params_with_auto_encode_arrays
+    connection = pg_connection(auto_encode_arrays: true).prepared
+
+    num = 1
+    date = Date.new(2020, 10, 10)
+    ints = [1, 2, 3]
+    row = connection.query_single("select :num::int, :date::date, :ints::int[]", num: num, date: date, ints: ints)
+
+    assert_equal(row, [num, date, ints])
+  end
 end

--- a/test/mini_sql/prepared_connection_tests.rb
+++ b/test/mini_sql/prepared_connection_tests.rb
@@ -14,7 +14,7 @@ module MiniSql::PreparedConnectionTests
   end
 
   def test_disable_prepared
-    @connection.prepared(false).exec('select 1')
+    @connection.unprepared.exec('select 1')
     assert_nil(last_prepared_statement)
   end
 

--- a/test/mini_sql/sqlite/prepared_connection_test.rb
+++ b/test/mini_sql/sqlite/prepared_connection_test.rb
@@ -7,9 +7,9 @@ class MiniSql::Sqlite::TestPreparedConnection < Minitest::Test
 
   def setup
     @unprepared_connection = sqlite3_connection
-    @prepared_connection = @unprepared_connection.prepared
+    @connection = @unprepared_connection.prepared
 
-    super
+    setup_tables
   end
 
   STMT_SQL = "select * from sqlite_stmt"
@@ -26,7 +26,7 @@ class MiniSql::Sqlite::TestPreparedConnection < Minitest::Test
   end
 
   def test_boolean_param
-    r = @prepared_connection.query("SELECT * FROM posts WHERE active = ?", 1)
+    r = @connection.query("SELECT * FROM posts WHERE active = ?", 1)
 
     assert_last_stmt "SELECT * FROM posts WHERE active = $1"
     assert_equal 2, r[0].id


### PR DESCRIPTION
1. full testing for `auto_encode_arrays` (prepared, unprepared)
2. refactoring prepared connection (simplify `prepared` method)
3. performance improved
4. more compatible with `ActiveRecord`